### PR TITLE
fix: add more default colors to the scatterplot

### DIFF
--- a/src/visualizations/ScatterPlot/ScatterPlot.tsx
+++ b/src/visualizations/ScatterPlot/ScatterPlot.tsx
@@ -50,6 +50,7 @@ const BaseScatterPlot = (props: {
   return (
     <NivoScatterPlot<Dots>
       data={data}
+      colors={{ scheme: "spectral" }}
       theme={darkTheme}
       margin={{ top: 60, right: 60, bottom: 70, left: 90 }}
       xScale={{ type: "linear", min: "auto", max: "auto" }}


### PR DESCRIPTION
Another easy option is to specify an array of colors - we could do something smart to calculate what a good set would be based on the number of 'groups'

<img width="1662" alt="Screen Shot 2023-02-09 at 9 57 42 AM" src="https://user-images.githubusercontent.com/10017022/217849423-d1906f58-8266-4677-998f-7801a6cc1af2.png">
